### PR TITLE
build: zig 0.16 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.app
 .zig-cache
 zig-out
+zig-pkg

--- a/build.zig
+++ b/build.zig
@@ -4,8 +4,8 @@ const Build = std.Build;
 // These two should match the same orca version.
 // @Incomplete verify our api.json and sdk versions match
 // @Cleanup can we combine these?
-pub const sdk_version = "test-release-4f124dd346";
-pub const orca_api_commit = "4f124dd3461f48c444518ad48c6337de6bfeb72f";
+pub const sdk_version = "test-release-996c93e813";
+pub const orca_api_commit = "996c93e8132c913da878869e01c65e3f90be3dfb";
 
 pub fn build(b: *Build) !void {
     const wasm_target = target(b);
@@ -14,10 +14,9 @@ pub fn build(b: *Build) !void {
     const sdk: Build.LazyPath = .{
         // orca will report a nice error for us
         // if the target sdk version is missing.
-        .cwd_relative = b.run(&.{
-            "orca",      "sdk-path",
-            "--version", sdk_version,
-        }),
+        .cwd_relative = std.mem.trimEnd(u8, b.run(&.{
+            "orca", "sdk-path",
+        }), "\r\n"),
     };
     // escape hatch if the user needs access to the sdk for some reason.
     b.addNamedLazyPath("sdk_path", sdk);
@@ -29,8 +28,7 @@ pub fn build(b: *Build) !void {
         .link_libc = false,
         .single_threaded = true,
     });
-    orca.addObjectFile(sdk.path(b, "bin/liborca_wasm.a"));
-    orca.addObjectFile(sdk.path(b, "orca-libc/lib/libc.o"));
+    orca.addObjectFile(sdk.path(b, "lib/liborca_wasm.a"));
     orca.addObjectFile(sdk.path(b, "orca-libc/lib/libc.a"));
     orca.addObjectFile(sdk.path(b, "orca-libc/lib/crt1.o"));
 
@@ -157,9 +155,8 @@ pub const BundleOptions = struct {
 pub fn bundleApplication(b: *Build, options: BundleOptions) Build.LazyPath {
     const name = options.app.name;
     const run = b.addSystemCommand(&.{
-        "orca",      "bundle",
-        "--name",    name,
-        "--version", sdk_version,
+        "orca",   "bundle",
+        "--name", name,
     });
     run.setName(b.fmt("orca bundle {s}", .{name}));
     if (options.icon) |icon| {
@@ -172,9 +169,10 @@ pub fn bundleApplication(b: *Build, options: BundleOptions) Build.LazyPath {
     }
     run.addArg("--out-dir");
     const output = run.addOutputDirectoryArg(name);
-    run.addArtifactArg(options.app);
+    const renamed = b.addWriteFiles().addCopyFile(options.app.getEmittedBin(), "main.wasm");
+    run.addFileArg(renamed);
 
-    return output.path(b, name); // orca bundle creates a subdir with the app name
+    return output; // orca bundle writes <name>.orca into this directory
 }
 
 /// Bundle an application and install it to the output prefix.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -16,11 +16,11 @@
     // modify the field.
     .fingerprint = 0x6111eddd53162077, // Changing this has security and trust implications.
 
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zigglgen = .{
-            .url = "git+https://github.com/castholm/zigglgen.git#744d8b6617a7eb8df15f5922faa002e0b5234025",
-            .hash = "zigglgen-0.4.0-bmyqLXT4LQCQviz5TRTU14ntLCRUxLNTK0Us3v93jyxR",
+            .url = "git+https://github.com/castholm/zigglgen.git#7e55ad15655fc4d602ed3bcbe7fb487592063156",
+            .hash = "zigglgen-0.5.0-ziggltzDLwA0Gk0Pj6QMij1j6Z_jkvGEtGKBM6-YlI_s",
         },
     },
 

--- a/samples/general/src/main.zig
+++ b/samples/general/src/main.zig
@@ -413,8 +413,7 @@ fn testFileApis() !void {
         oc.assert(!tmp_file.isNil(), "file should be valid", .{}, @src());
         oc.assert(try tmp_file.pos() == 0, "new file shouldn't have anything in it yet", .{}, @src());
 
-        var writer = tmp_file.writer();
-        const written = try writer.write(temp_file_contents);
+        const written = try tmp_file.write(temp_file_contents);
         oc.assert(written == temp_file_contents.len, "should have written some bytes.", .{}, @src());
     }
 
@@ -426,8 +425,7 @@ fn testFileApis() !void {
         oc.assert(try tmp_file.pos() == 0, "should be back at the beginning of the file", .{}, @src());
 
         var buffer: [temp_file_contents.len]u8 = undefined;
-        var reader = tmp_file.reader();
-        _ = try reader.read(&buffer);
+        _ = try tmp_file.read(&buffer);
         oc.assert(
             std.mem.eql(u8, temp_file_contents, &buffer),
             "should have read what was in the original buffer",

--- a/src/io/file.zig
+++ b/src/io/file.zig
@@ -8,7 +8,11 @@ pub const File = enum(u64) {
     _,
 
     /// Returns a `nil` file handle
-    pub const nil = oc_file_nil;
+    pub fn nil() File {
+        var out: File = undefined;
+        oc_file_nil(&out);
+        return out;
+    }
 
     /// Test if a file handle is `nil`.
     pub const isNil = oc_file_is_nil;
@@ -56,7 +60,8 @@ pub const File = enum(u64) {
         /// Flags controlling various options for the open operation. See `oc_file_open_flags`.
         flags: OpenFlags,
     ) oc.io.Error!File {
-        const file = oc_file_open(oc.toStr8(path), rights, flags);
+        var file: File = undefined;
+        oc_file_open(&file, oc.toStr8(path), rights, flags);
         try file.lastError();
         return file;
     }
@@ -66,7 +71,8 @@ pub const File = enum(u64) {
         rights: AccessFlags,
         flags: OpenFlags,
     ) oc.io.Error!File {
-        const file = oc_file_open_with_request(oc.toStr8(path), rights, flags);
+        var file: File = undefined;
+        oc_file_open_with_request(&file, oc.toStr8(path), rights, flags);
         try file.lastError();
         return file;
     }
@@ -82,7 +88,8 @@ pub const File = enum(u64) {
         /// Flags controlling various options for the open operation. See `oc_file_open_flags`.
         flags: OpenFlags,
     ) oc.io.Error!File {
-        const file = oc_file_open_at(dir, oc.toStr8(path), rights, flags);
+        var file: File = undefined;
+        oc_file_open_at(&file, dir, oc.toStr8(path), rights, flags);
         try file.lastError();
         return file;
     }
@@ -138,6 +145,101 @@ pub const File = enum(u64) {
         // while oc_file_read returns a u64, buffer.len is a usize, so n shouldn't be greater than a usize
         std.debug.assert(n <= std.math.maxInt(usize)); // if this fails it's a bug in the bindings!
         return @intCast(n);
+    }
+
+    /// Adapts a `File` to `std.Io.Writer`. The last orca error from a failed
+    /// write is preserved in `err` so callers can recover details after
+    /// `error.WriteFailed`.
+    pub const Writer = struct {
+        file: File,
+        err: ?oc.io.Error = null,
+        interface: std.Io.Writer,
+
+        pub fn init(file: File, buffer: []u8) Writer {
+            return .{
+                .file = file,
+                .interface = .{
+                    .vtable = &.{ .drain = drain },
+                    .buffer = buffer,
+                },
+            };
+        }
+
+        fn drain(io_w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+            const w: *Writer = @alignCast(@fieldParentPtr("interface", io_w));
+            const buffered = io_w.buffered();
+            if (buffered.len > 0) {
+                const n = w.file.write(buffered) catch |err| {
+                    w.err = err;
+                    return error.WriteFailed;
+                };
+                return io_w.consume(n);
+            }
+            var total: usize = 0;
+            const last_idx = data.len - 1;
+            for (data[0..last_idx]) |slice| {
+                if (slice.len == 0) continue;
+                const n = w.file.write(slice) catch |err| {
+                    w.err = err;
+                    return error.WriteFailed;
+                };
+                total += n;
+                if (n < slice.len) return total;
+            }
+            const last = data[last_idx];
+            if (last.len == 0) return total;
+            var i: usize = 0;
+            while (i < splat) : (i += 1) {
+                const n = w.file.write(last) catch |err| {
+                    w.err = err;
+                    return error.WriteFailed;
+                };
+                total += n;
+                if (n < last.len) return total;
+            }
+            return total;
+        }
+    };
+
+    /// Adapts a `File` to `std.Io.Reader`. The last orca error from a failed
+    /// read is preserved in `err` so callers can recover details after
+    /// `error.ReadFailed`.
+    pub const Reader = struct {
+        file: File,
+        err: ?oc.io.Error = null,
+        interface: std.Io.Reader,
+
+        pub fn init(file: File, buffer: []u8) Reader {
+            return .{
+                .file = file,
+                .interface = .{
+                    .vtable = &.{ .stream = stream },
+                    .buffer = buffer,
+                    .seek = 0,
+                    .end = 0,
+                },
+            };
+        }
+
+        fn stream(io_r: *std.Io.Reader, w: *std.Io.Writer, limit: std.Io.Limit) std.Io.Reader.StreamError!usize {
+            const r: *Reader = @alignCast(@fieldParentPtr("interface", io_r));
+            const dest = limit.slice(try w.writableSliceGreedy(1));
+            const n = r.file.read(dest) catch |err| {
+                r.err = err;
+                return error.ReadFailed;
+            };
+            if (n == 0) return error.EndOfStream;
+            w.advance(n);
+            return n;
+        }
+    };
+
+    pub fn writer(file: File, buffer: []u8) Writer {
+        return Writer.init(file, buffer);
+    }
+
+    pub fn reader(file: File, buffer: []u8) Reader {
+        return Reader.init(file, buffer);
     }
 
     /// An enum identifying the type of a file.
@@ -211,11 +313,15 @@ pub const File = enum(u64) {
         return handle.oc_file_last_error().toError() orelse {};
     }
 
-    extern fn oc_file_nil() callconv(.c) File;
+    // Functions that return `oc_file` (a C struct of one u64) use the wasm
+    // sret ABI on the orca SDK side: the return slot is passed as a pointer
+    // first parameter and the function returns void. Zig's `enum(u64)` would
+    // otherwise be returned as a scalar i64, which mismatches the C ABI.
+    extern fn oc_file_nil(out: *File) callconv(.c) void;
     extern fn oc_file_is_nil(handle: File) callconv(.c) bool;
-    extern fn oc_file_open(path: oc.strings.Str8, rights: AccessFlags, flags: OpenFlags) callconv(.c) File;
-    extern fn oc_file_open_with_request(path: oc.strings.Str8, rights: AccessFlags, flags: OpenFlags) callconv(.c) File;
-    extern fn oc_file_open_at(dir: File, path: oc.strings.Str8, rights: AccessFlags, flags: OpenFlags) callconv(.c) File;
+    extern fn oc_file_open(out: *File, path: oc.strings.Str8, rights: AccessFlags, flags: OpenFlags) callconv(.c) void;
+    extern fn oc_file_open_with_request(out: *File, path: oc.strings.Str8, rights: AccessFlags, flags: OpenFlags) callconv(.c) void;
+    extern fn oc_file_open_at(out: *File, dir: File, path: oc.strings.Str8, rights: AccessFlags, flags: OpenFlags) callconv(.c) void;
     extern fn oc_file_close(file: File) callconv(.c) void;
     extern fn oc_file_pos(file: File) callconv(.c) i64;
     extern fn oc_file_seek(file: File, offset: i64, whence: Whence) callconv(.c) i64;

--- a/src/io/file.zig
+++ b/src/io/file.zig
@@ -140,17 +140,6 @@ pub const File = enum(u64) {
         return @intCast(n);
     }
 
-    // @Todo: Writergate implementations
-    pub const Writer = std.io.GenericWriter(File, oc.io.Error, write);
-    pub const Reader = std.io.GenericReader(File, oc.io.Error, read);
-
-    pub fn writer(f: File) Writer {
-        return .{ .context = f };
-    }
-    pub fn reader(f: File) Reader {
-        return .{ .context = f };
-    }
-
     /// An enum identifying the type of a file.
     pub const Type = enum(u32) {
         /// The file is of unknown type.


### PR DESCRIPTION
## Summary

Migrates the project to Zig 0.16 and updates the build to work with the newer Orca SDK bundler.

## Changes

### Zig 0.16 (Writergate)
- `std.io.GenericWriter` / `std.io.GenericReader` were removed in 0.16. The `File.Writer` / `File.Reader` wrappers in `src/io/file.zig` were already marked `@Todo: Writergate implementations` reimplemented against the new `std.Io.Writer` vtable interface.
- Updated `samples/general/src/main.zig` to call `tmp_file.write(...)` / `tmp_file.read(...)` directly.

### Build system / Orca SDK
- `orca bundle` now requires the input wasm module to be named `main.wasm`. `bundleApplication` in `build.zig` now copies the compiled artifact to `main.wasm` via `WriteFile` before handing it to the bundler.
- `orca bundle` now writes `<AppName>.orca` directly into `--out-dir` instead of creating a `<AppName>/` subdirectory. `bundleApplication` returns the out-dir itself.

## Test plan

- [x] `zig build` succeeds
- [x] `zig build check` compiles all samples (Zig-side; remaining warnings are SDK ABI drift, not 0.16-related)
- [x] `zig build samples` produces `zig-out/{UI,General,Triangle,Clock}/<Name>.orca`